### PR TITLE
Instance normalization: enabled affine transformation by default

### DIFF
--- a/highresnet/highresnet.py
+++ b/highresnet/highresnet.py
@@ -304,7 +304,7 @@ class ConvolutionalBlock(nn.Module):
 
         if preactivation:
             if batch_norm or instance_norm:
-                layers.append(norm_class(in_channels))
+                layers.append(norm_class(in_channels, affine=True))
             if activation:
                 layers.append(nn.ReLU())
 
@@ -323,7 +323,7 @@ class ConvolutionalBlock(nn.Module):
 
         if not preactivation:
             if batch_norm or instance_norm:
-                layers.append(norm_class(out_channels))
+                layers.append(norm_class(out_channels, affine=True))
             if activation:
                 layers.append(nn.ReLU())
 


### PR DESCRIPTION
BatchNorm has a default affine=True, which makes bias term unnecessary,
but the InstanceNorm default is affine=False, because of historical reasons.
While it is an open issue in Pytorch, see https://github.com/pytorch/pytorch/issues/22755,
it would be better to make it explicit. (Let's assume the defaults change, it is better
to be explicit. Otherwise line 314 could be also simply changed to 
```use_bias = not batch_norm``` )

Long story short: InstanceNorm needs bias term, and i think the PR is a reasonable solution.
(But obviously test it.) In case of accepted PR, a new Pypi release would be nice too.